### PR TITLE
Add missing clause to clarify trustee removal

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -245,6 +245,8 @@ Software Engineering (The “Society”)
 
     * 10.4.2 Any decision to wind up or dissolve the CIO must be taken in accordance with clause 29 (Voluntary winding up or dissolution). Any decision to amalgamate or transfer the undertaking of the CIO to one or more other CIOs must be taken in accordance with the provisions of the Charities Act 2011.
 
+    * 10.4.3 Any decision by the members of the CIO to remove a charity trustee must be taken in accordance with clause 15.2.
+
 ## 11 GENERAL MEETINGS OF MEMBERS
 
 * 11.1 Types of general meeting


### PR DESCRIPTION
This change clarifies the process of trustee removal but does not directly change the meaning of this section.

Rationale: With respect to members voting to remove a trustee. The Charity Commission's model
constitution suggests this clause should be present when clause 15.2 is present. I.e. On page 25 of the
model constitution we have already chosen to include clause 15.2. Page 15 then says that clause
10(4)(a) should be included in this case. This seems to have simply been an accidental omission in the
original drafting.