### PR TITLE
Fix spelling mistake in founding trustee name

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -429,7 +429,7 @@ Software Engineering (The “Society”)
 
         Mr Robert Haines;
 
-        Dr Sumon Hettrick;
+        Dr Simon Hettrick;
 
         Dr Matthew Johnson;
 


### PR DESCRIPTION
This change fixes a single typo in the name of a founding trustee. Founding trustees must be listed in the constitution.

Rationale: To correct a spelling mistake in one of the founding trustees names.