### PR TITLE
Resolution 1: Allow STV as a voting method for trustee elections

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -247,6 +247,8 @@ Software Engineering (The “Society”)
 
     * 10.4.3 Any decision by the members of the CIO to remove a charity trustee must be taken in accordance with clause 15.2.
 
+    * 10.4.4 Any decision by the members to elect trustees of the CIO may be performed using a single-transferable vote based on a ranked-choice list of candidates. In this case, the specific version of single transferable vote used to choose the winners must be provided at the time that the voting opens.
+
 ## 11 GENERAL MEETINGS OF MEMBERS
 
 * 11.1 Types of general meeting


### PR DESCRIPTION
By default, as per clause 11.6.1, all decisions by the membership are by a simple majority. This currently includes the election of trustees. However, this is not always suitable. For example, a simple yes/no decision does not work well for when there are N candidates for M positions. 

We are proposing allowing the use of a single transferable vote (STV) system for elections where it is appropriate. This is a system designed for fairly selecting between candidates when there are multiple positions available and rules out traditional “tactical voting”. For more information on STV see details from [the Electoral Reform Society](https://www.electoral-reform.org.uk/voting-systems/types-of-voting-system/single-transferable-vote/), [OpaVote](https://www.opavote.com/methods/single-transferable-vote) and [the Royal Statistical Society](https://rss.org.uk/news-publication/news-publications/2022/member-callouts/an-update-on-the-rss%E2%80%99s-voting-method/).

There are numerous variants of STV (e.g. Scottish STV or Meek STV), changing how votes are redistributed, which each have their pros and cons. To avoid locking this choice into the constitution we propose flexibility in the choice, but that it must be communicated clearly to the membership at election time.