### PR TITLE
Resolution 2: Require only one third of trustees to retire

### DIFF
--- a/constitution.md
+++ b/constitution.md
@@ -449,7 +449,7 @@ Software Engineering (The “Society”)
 
 ## 13 APPOINTMENT OF CHARITY TRUSTEES
 
-* 13.1 At every annual general meeting of the members of the CIO, one half of the charity trustees shall retire from office. If the number of charity trustees is not a multiple of two, then the number of trustees to retire shall not exceed one-half of all trustees;
+* 13.1 At every annual general meeting of the members of the CIO, one third of the charity trustees shall retire from office. If the number of charity trustees is not a multiple of three, then the number of trustees required to retire shall not exceed one third of all trustees;
 
 * 13.2 The charity trustees to retire by rotation shall be those who have been longest in office since their last appointment or reappointment. If any trustees were last appointed or reappointed on the same day those to retire shall (unless they otherwise agree among themselves) be determined by lot;
 


### PR DESCRIPTION
At present one-half of the trustees stand down each year at the AGM. The trustees chosen to stand down are those who have been the longest in office (see clause 13.2). This means that there is an effective two-year term for trustees.

This leads to high churn in the board and a difficulty in maintaining institutional knowledge as well as lost time due to onboarding and mentoring of new trustees. In the recent [governance review from the NCVO](https://society-rse.org/ncvo-governance-review/) it was recommended that we alter this to a one-third stepping down (an effective three-year term) which is also the default in the Charity Commission’s model constitution. After extensive discussion among the trustees, we decided to propose this change to the membership.